### PR TITLE
Add stacks for assets and scripts on render tile

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -9,6 +9,8 @@
 
         {{ $assets }}
 
+        @stack('assets')
+
         <livewire:styles />
     </head>
     <body class="leading-snug">
@@ -25,6 +27,8 @@
         </div>
 
         <livewire:scripts />
+
+        @stack('scripts')
 
         <script>
             const theme = (theme, initialMode) => ({


### PR DESCRIPTION
I am creating some chart tiles  where the inline script is unique per render so I am unable to use `Dashboard::inlineScript'. See example:

```php
<x-dashboard-tile :position="$position" >
    <div class="grid grid-rows-auto-1 gap-2" wire:poll.{{$refreshIntervalInSeconds}}s>
        {!! $chart->container() !!}
    </div>
    {!! $chart->script() !!}
    <script>
        document.addEventListener('DOMContentLoaded', function () {
            window.livewire.on('polledEvent{{$wireId}}', function () {
                {{ $chart->id }}_rendered = false;
                {{ $chart->id }}_load();
            });
        });
    </script>
</x-dashboard-tile>
```
Because the script is being rendered in line I have to add the `DOMContentLoaded`. However, with this change I am able to place my scripts below the livewire ones and it works as expected:

```php
<x-dashboard-tile :position="$position" >
    <div class="grid grid-rows-auto-1 gap-2" wire:poll.{{$refreshIntervalInSeconds}}s>
        {!! $chart->container() !!}
    </div>
    @push('scripts')
        {!! $chart->script() !!}
        <script> 
            window.livewire.on('polledEvent{{$wireId}}', function () {
                 {{ $chart->id }}_rendered = false;
                 {{ $chart->id }}_load();
            });
        </script>
    @endpush
</x-dashboard-tile>
```

Also means in this instance I can remove the `document.addEventListener` as livewire will be loaded