### PR TITLE
Add Health Check tile

### DIFF
--- a/docs/adding-tiles/overview.md
+++ b/docs/adding-tiles/overview.md
@@ -21,6 +21,7 @@ Here are tiles created by the community:
 - [Cloudflare Stats](https://github.com/owenvoke/laravel-dashboard-cloudflare-stats-tile): display statistics from Cloudflare
 - [Football standings](https://github.com/kayschima/laravel-dashboard-footballdata-standings-tile): display football standings (powered by [football-data.org](https://football-data.org))
 - [Google Fit](https://github.com/owenvoke/laravel-dashboard-google-fit-tile): display statistics from Google Fit
+- [Health Check](https://github.com/tylerwoonton/laravel-dashboard-health-check-tile): display health of your applications using the [Laravel Health Check](https://github.com/ukfast/laravel-health-check) package
 - [Offset Earth](https://github.com/owenvoke/laravel-dashboard-offset-earth-tile): display statistics from Offset Earth
 - [Pi-hole](https://github.com/owenvoke/laravel-dashboard-pihole-tile): display statistics from Pi-hole
 - [PingPing](https://github.com/Astrotomic/laravel-dashboard-pingping-tile): display sites monitored by [PingPing](https://pingping.io)


### PR DESCRIPTION
I've created a tile to monitor the health of applications using the [ukfast/laravel-health-check](https://github.com/ukfast/laravel-health-check) package and would like to add it to the community list.