### PR TITLE
Add the missing \ in front of the schedule commands

### DIFF
--- a/docs/adding-tiles/time-weather.md
+++ b/docs/adding-tiles/time-weather.md
@@ -48,8 +48,8 @@ If you want to rain forecast, and the Buienradar service supports your location,
 protected function schedule(Schedule $schedule)
 {
     // ...
-    $schedule->command(Spatie\TimeWeatherTile\Commands\FetchOpenWeatherMapDataCommand::class)->everyMinute();
-    $schedule->command(Spatie\TimeWeatherTile\Commands\FetchBuienradarForecastsCommand::class)->everyMinute();
+    $schedule->command(\Spatie\TimeWeatherTile\Commands\FetchOpenWeatherMapDataCommand::class)->everyMinute();
+    $schedule->command(\Spatie\TimeWeatherTile\Commands\FetchBuienradarForecastsCommand::class)->everyMinute();
 }
 ```
 


### PR DESCRIPTION
Without that \ it tries to find App\Console\Spatie\TimeWeatherTile\Commands\FetchOpenWeatherMapDataCommand and App\Console\Spatie\TimeWeatherTile\Commands\FetchBuienradarForecastsCommand (in a default Laravel installation.

The most users will understand it but this change made it clear.