### PR TITLE
Typo 'livewire:belgian-trains-tile' instead of  'livewire:velo-tile'

### DIFF
--- a/docs/adding-tiles/belgian-trains.md
+++ b/docs/adding-tiles/belgian-trains.md
@@ -51,7 +51,7 @@ protected function schedule(Schedule $schedule)
 
 ## Usage
 
-In your dashboard view you use the `livewire:velo-tile` component. 
+In your dashboard view you use the `livewire:belgian-trains-tile` component. 
 
 ```html
 <x-dashboard>


### PR DESCRIPTION
I was just checking out your awesome dashboard and discovered this small typo.