### PR TITLE
added laravel-dashboard-npm

### DIFF
--- a/docs/adding-tiles/overview.md
+++ b/docs/adding-tiles/overview.md
@@ -24,6 +24,7 @@ Here are tiles created by the community:
 - [Forge](https://github.com/aglipanci/laravel-dashboard-forge-tile): display information from [Laravel Forge](https://forge.laravel.com)
 - [Google Fit](https://github.com/owenvoke/laravel-dashboard-google-fit-tile): display statistics from Google Fit
 - [Health Check](https://github.com/tylerwoonton/laravel-dashboard-health-check-tile): display health of your applications using the [Laravel Health Check](https://github.com/ukfast/laravel-health-check) package
+- [npm downloads](https://github.com/skydiver/laravel-dashboard-npm): Show npm packages stats
 - [Offset Earth](https://github.com/owenvoke/laravel-dashboard-offset-earth-tile): display statistics from Offset Earth
 - [Packagist data](https://packagist.org/packages/tjvb/laravel-dashboard-packagist-tile): Display statistics from Packagist (downloads, favers, github stars) or the packages you want to folow.
 - [Pi-hole](https://github.com/owenvoke/laravel-dashboard-pihole-tile): display statistics from Pi-hole


### PR DESCRIPTION
Adds `laravel-dashboard-npm` package to display npm download stats.