### PR TITLE
Update the changelog link in the docs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,4 +3,4 @@ title: Changelog
 weight: 6
 ---
 
-All notable changes to laravel-dashboard are documented [on GitHub](https://github.com/spatie/laravel-dashboard/blob/master/docs/changelog.md)
+All notable changes to laravel-dashboard are documented [on GitHub](https://github.com/spatie/laravel-dashboard/blob/master/CHANGELOG.md)


### PR DESCRIPTION
Update the changelog link in the docs to point to the changelog.md in the root of the project on GitHub.

As reported in #54 