### PR TITLE
Ability to not load external dependencies

### DIFF
--- a/src/DashboardServiceProvider.php
+++ b/src/DashboardServiceProvider.php
@@ -14,10 +14,17 @@ class DashboardServiceProvider extends ServiceProvider
 {
     public function boot()
     {
-        $this->app->make(Dashboard::class)
-            ->script(config('dashboard.scripts.alpinejs'))
-            ->stylesheet(config('dashboard.stylesheets.inter'))
-            ->inlineStylesheet(file_get_contents(__DIR__.'/../resources/dist/dashboard.min.css'));
+        $dashboard = $this->app->make(Dashboard::class);
+
+        if ($alpine = config('dashboard.scripts.alpinejs')) {
+            $dashboard->script($alpine);
+        }
+
+        if ($inter = config('dashboard.stylesheets.inter')) {
+            $dashboard->stylesheet($inter);
+        }
+
+        $dashboard->inlineStylesheet(file_get_contents(__DIR__.'/../resources/dist/dashboard.min.css'));
 
         $this->loadViewsFrom(__DIR__ . '/../resources/views', 'dashboard');
 


### PR DESCRIPTION
This allows to avoid loading external dependencies.

In my case I need to use local javascript files which include Alpine v3 and other dependencies (eg dayjs, ...) compiled with Laravel Mix using the `extract()` method.

I then emptied the "scripts" configuration and included the javascript in the file `resources/views/vendor/dashboard/dashboard.blade.php` (manifest.js, vendor.js, ...).

Prior to this PR, clearing the "scripts" or "styles" configuration raises an exception like:
`Spatie\Dashboard\Dashboard::script(): Argument #1 ($url) must be of type string, null given`