### PR TITLE
Add livewire hook to refresh page on 419 error.

### DIFF
--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -47,11 +47,3 @@ return [
 ];
 ```
 
-In order for the dashboard to run constantly without anybody having to refresh it every once in a while, you need to add an exception for Livewire routes in your `VerifyCsrfToken` middleware (/app/Http/Middleware/VerifyCsrfToken.php):
-
-```php
-protected $except = [
-    '/livewire/*',
-];
-```
-Livewire uses AJAX requests to update the components. Those AJAX requests contain a [CSRF token](https://laravel.com/docs/7.x/csrf#csrf-x-csrf-token), and at some point that token will expire and you will see a `419 Page Expired` error in your dashboard. This will prevent it from happening.

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -67,6 +67,10 @@
                     })
                 },
             });
+
+            Livewire.onPageExpired(() => {
+                window.location.reload();
+            });
         </script>
 
 


### PR DESCRIPTION
Thank you for this awesome package!

The documentation says, that the livewire routes should be excluded from the CSRF verification to enable permanent refreshing.

This seems a bit odd to me, especially if there are other pages, that use livewire, in the same app.

On the other hand, livewire provides a way to define a callback, that gets called if a 419 error occurred, instead of the default confirm dialog.

As we most likely want to refresh our dashboard in this case to preserve refresh capabilities, the page could be refreshed without any confirmation.

Maybe I'm not seeing the complete picture here, but I thought this might be a suitable change for a dashboard!