### PR TITLE
add config item to allow dashboard to be used on a content pane instead of consuming entire page

### DIFF
--- a/config/dashboard.php
+++ b/config/dashboard.php
@@ -26,4 +26,9 @@ return [
     'stylesheets' => [
         'inter' => 'https://rsms.me/inter/inter.css',
     ],
+
+    /**
+     *  A flag to tell if the dashboard is a single page or not.
+     */
+    'single_page' => false,
 ];

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,11 +1,25 @@
+@if (config('dashboard.single_page'))
+    <!DOCTYPE html>
+    <html lang="en">
 
-<div
-    x-data="theme('{{ $theme }}', '{{ $initialMode }}')"
-    x-init="init"
-    :class="mode === 'dark' ? 'dark-mode' : ''"
->
+    <head>
+        <title>Dashboard</title>
+        <meta name="google" value="notranslate">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
+        <meta name="apple-mobile-web-app-capable" content="yes">
+        <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+
+        {{ $assets }}
+
+        @stack('assets')
+    </head>
+
+    <body class="leading-snug">
+@endif
+
+<div x-data="theme('{{ $theme }}', '{{ $initialMode }}')" x-init="init" :class="mode === 'dark' ? 'dark-mode' : ''">
     <div class="fixed inset-0 w-screen h-screen grid gap-2 p-2 bg-canvas text-default">
-        <livewire:dashboard-update-mode/>
+        <livewire:dashboard-update-mode />
 
         {{ $slot }}
     </div>
@@ -52,8 +66,13 @@
     });
 
     document.addEventListener('livewire:init', () => {
-        Livewire.hook('request', ({ fail }) => {
-            fail(({ status, preventDefault }) => {
+        Livewire.hook('request', ({
+            fail
+        }) => {
+            fail(({
+                status,
+                preventDefault
+            }) => {
                 if (status === 419) {
                     preventDefault();
 
@@ -63,4 +82,8 @@
         });
     });
 </script>
+@if (config('dashboard.single_page'))
+    </body>
 
+    </html>
+@endif

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,17 +1,4 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <title>Dashboard</title>
-    <meta name="google" value="notranslate">
-    <meta name="csrf-token" content="{{ csrf_token() }}">
-    <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 
-    {{ $assets }}
-
-    @stack('assets')
-</head>
-<body class="leading-snug">
 <div
     x-data="theme('{{ $theme }}', '{{ $initialMode }}')"
     x-init="init"
@@ -77,6 +64,3 @@
     });
 </script>
 
-
-</body>
-</html>


### PR DESCRIPTION
This might not be the nicest code.
We add a config item to dashboard to flag if we want a single_page view or not, then we test for this in the dashboard view and hide the page tags (html, head,body) if we want it as a content pane.