### PR TITLE
Remove the packagist tile from the list because I have abandoned it.

### DIFF
--- a/docs/adding-tiles/overview.md
+++ b/docs/adding-tiles/overview.md
@@ -32,7 +32,6 @@ Here are tiles created by the community:
 - [Laravel news](https://github.com/dietercoopman/laravel-dashboard-laravelnews-tile): Display the latest Laravel news articles in a loop.
 - [npm downloads](https://github.com/skydiver/laravel-dashboard-npm): Show npm packages stats
 - [Offset Earth](https://github.com/owenvoke/laravel-dashboard-offset-earth-tile): display statistics from Offset Earth
-- [Packagist data](https://packagist.org/packages/tjvb/laravel-dashboard-packagist-tile): Display statistics from Packagist (downloads, favers, github stars) or the packages you want to folow.
 - [Paystack - Customers](https://github.com/digikraaft/laravel-dashboard-paystack-customers-tile): show recent Paystack customers
 - [Paystack - Subscriptions](https://github.com/digikraaft/laravel-dashboard-paystack-subscriptions-tile): show recent Paystack subscriptions)
 - [Paystack - Transactions](https://github.com/digikraaft/laravel-dashboard-paystack-transactions-tile): Display recent transactions from Stripe


### PR DESCRIPTION
Now more then 4 years after the first release this package need a new major version. I came to the conclusion that I need to be honest and will not keep maintaining this package.

I didn't find anyone interested to maintain it so now I have abandoned this tile. I think it is a good reason to remove it from this list. (It also doesn't support the latest version of spatie/larvel-dashboard.