### PR TITLE
Feature: Customise Page Title

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title>Dashboard</title>
+    <title>{{ $pageTitle }}</title>
     <meta name="google" value="notranslate">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <meta name="apple-mobile-web-app-capable" content="yes">

--- a/src/Components/DashboardComponent.php
+++ b/src/Components/DashboardComponent.php
@@ -8,19 +8,22 @@ use Spatie\Dashboard\Dashboard;
 
 class DashboardComponent extends Component
 {
+    public string $pageTitle = '';
     public string $theme = '';
 
     public string $initialMode = '';
 
     public ?HtmlString $assets = null;
 
-    public function __construct(Dashboard $dashboard)
+    public function __construct(Dashboard $dashboard, string $pageTitle='Dashboard')
     {
         $this->theme = $dashboard->getTheme();
 
         $this->initialMode = $dashboard->getMode();
 
         $this->assets = $dashboard->assets();
+
+        $this->pageTitle = $pageTitle;
     }
 
     public function render()


### PR DESCRIPTION
Small enhancement. I have created many dashboards, and when I look at them on a web browser rather than the full screen, it's useful to know which one is which - for example when I create browser bookmarks.

To use this in your view where you're calling the dashboard component just add a property. 

```
<x-dashboard pageTitle="My Cool Dashboard">
    {{-- replace this by any tiles --}}
</x-dashboard>
```