### PR TITLE
Update links and embedded images to v3

### DIFF
--- a/docs/adding-tiles/attendances.md
+++ b/docs/adding-tiles/attendances.md
@@ -5,7 +5,7 @@ weight: 9
 
 This tile displays who will be in the office this week, based upon Google calendar.
 
-![screenshot](https://spatie.be/docs/laravel-dashboard/v2/images/attendances.png)
+![screenshot](https://spatie.be/docs/laravel-dashboard/v3/images/attendances.png)
 
 ## Installation
 

--- a/docs/adding-tiles/belgian-trains.md
+++ b/docs/adding-tiles/belgian-trains.md
@@ -6,7 +6,7 @@ weight: 8
 This tile displays the status of trains in Belgium.
 
 
-![screenshot](https://spatie.be/docs/laravel-dashboard/v2/images/trains.png)
+![screenshot](https://spatie.be/docs/laravel-dashboard/v3/images/trains.png)
 
 ## Installation
 

--- a/docs/adding-tiles/creating-your-own-tile.md
+++ b/docs/adding-tiles/creating-your-own-tile.md
@@ -33,7 +33,7 @@ class DummyComponent extends Component
 }
 ```
 
-You should always accept a `position` via the mount function. This position will used [to position tiles on the dashboard](/docs/laravel-dashboard/v2/basic-usage/positioning-tiles).
+You should always accept a `position` via the mount function. This position will used [to position tiles on the dashboard](/docs/laravel-dashboard/v3/basic-usage/positioning-tiles).
 
 Here's how that `tiles.dummy` view could look like
 

--- a/docs/adding-tiles/google-calendar.md
+++ b/docs/adding-tiles/google-calendar.md
@@ -5,7 +5,7 @@ weight: 3
 
 This tile displays events on a Google calendar.
 
-![screenshot](https://spatie.be/docs/laravel-dashboard/v2/images/calendar.png)
+![screenshot](https://spatie.be/docs/laravel-dashboard/v3/images/calendar.png)
 
 ## Installation
 

--- a/docs/adding-tiles/oh-dear-uptime.md
+++ b/docs/adding-tiles/oh-dear-uptime.md
@@ -5,7 +5,7 @@ weight: 4
 
 This tile displays sites that [Oh Dear](https://ohdear.app) detects as down.
 
-![screenshot](https://spatie.be/docs/laravel-dashboard/v2/images/oh-dear.png)
+![screenshot](https://spatie.be/docs/laravel-dashboard/v3/images/oh-dear.png)
 
 ## Installation
 

--- a/docs/adding-tiles/overview.md
+++ b/docs/adding-tiles/overview.md
@@ -3,16 +3,16 @@ title: Overview
 weight: 1
 ---
 
-On the dashboard a collection of tiles is displayed. You can [create your own tile](/docs/laravel-dashboard/v2/adding-tiles/creating-your-own-tile) or use any of these pre packages ones.
+On the dashboard a collection of tiles is displayed. You can [create your own tile](/docs/laravel-dashboard/v3/adding-tiles/creating-your-own-tile) or use any of these pre packages ones.
 
 There are the tiles created by us:
 
-- [Time and Weather](/docs/laravel-dashboard/v2/adding-tiles/time-weather): displays the current time and weather at your location
-- [Calendar](/docs/laravel-dashboard/v2/adding-tiles/google-calendar): displays events that are on a Google Calendar
-- [Twitter](/docs/laravel-dashboard/v2/adding-tiles/twitter-tile): displays mentions on Twitter
-- [Oh Dear Uptime](/docs/laravel-dashboard/v2/adding-tiles/oh-dear-uptime): displays sites that are detected as down by [Oh Dear](https://ohdear.app)
-- [Belgian Trains](/docs/laravel-dashboard/v2/adding-tiles/belgian-trains): displays real-time info on Belgian trains
-- [Velo](/docs/laravel-dashboard/v2/adding-tiles/velo): displays the status of [Velo](https://www.velo-antwerpen.be/en), the Antwerp bike sharing system
+- [Time and Weather](/docs/laravel-dashboard/v3/adding-tiles/time-weather): displays the current time and weather at your location
+- [Calendar](/docs/laravel-dashboard/v3/adding-tiles/google-calendar): displays events that are on a Google Calendar
+- [Twitter](/docs/laravel-dashboard/v3/adding-tiles/twitter-tile): displays mentions on Twitter
+- [Oh Dear Uptime](/docs/laravel-dashboard/v3/adding-tiles/oh-dear-uptime): displays sites that are detected as down by [Oh Dear](https://ohdear.app)
+- [Belgian Trains](/docs/laravel-dashboard/v3/adding-tiles/belgian-trains): displays real-time info on Belgian trains
+- [Velo](/docs/laravel-dashboard/v3/adding-tiles/velo): displays the status of [Velo](https://www.velo-antwerpen.be/en), the Antwerp bike sharing system
 
 Here are tiles created by the community:
 

--- a/docs/adding-tiles/time-weather.md
+++ b/docs/adding-tiles/time-weather.md
@@ -5,7 +5,7 @@ weight: 3
 
 This tile displays the time, weather, and optionally a rain forecast.
 
-![screenshot](https://spatie.be/docs/laravel-dashboard/v2/images/time-weather.png)
+![screenshot](https://spatie.be/docs/laravel-dashboard/v3/images/time-weather.png)
 
 ## Installation
 

--- a/docs/adding-tiles/twitter-tile.md
+++ b/docs/adding-tiles/twitter-tile.md
@@ -5,7 +5,7 @@ weight: 5
 
 This tile displays Twitter mentions.
 
-![screenshot](https://spatie.be/docs/laravel-dashboard/v2/images/twitter.png)
+![screenshot](https://spatie.be/docs/laravel-dashboard/v3/images/twitter.png)
 
 ## Installation
 

--- a/docs/adding-tiles/velo.md
+++ b/docs/adding-tiles/velo.md
@@ -5,7 +5,7 @@ weight: 7
 
 This tile displays the status of [Velo](https://www.velo-antwerpen.be/en), the Antwerp bike sharing system.
 
-![screenshot](https://spatie.be/docs/laravel-dashboard/v2/images/velo.png)
+![screenshot](https://spatie.be/docs/laravel-dashboard/v3/images/velo.png)
 
 ## Installation
 

--- a/docs/basic-usage/creating-your-first-dashboard.md
+++ b/docs/basic-usage/creating-your-first-dashboard.md
@@ -17,7 +17,7 @@ In your Blade view, use the `dashboard` Blade view component.
 </x-dashboard>
 ```
 
-Inside the `x-dashboard` tag, you can use any of [available tiles](/docs/laravel-dashboard/v2/adding-tiles/overview). You can also [create your own tile](/docs/laravel-dashboard/v2/adding-tiles/creating-your-own-tile/).
+Inside the `x-dashboard` tag, you can use any of [available tiles](/docs/laravel-dashboard/v3/adding-tiles/overview). You can also [create your own tile](/docs/laravel-dashboard/v3/adding-tiles/creating-your-own-tile/).
 
 Here's an example
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -5,11 +5,11 @@ weight: 1
 
 Using this package you can create a beautiful dashboard Like this one.
 
-![Screenshot of dashboard](https://spatie.be/docs/laravel-dashboard/v2/images/dashboard.png)
+![Screenshot of dashboard](https://spatie.be/docs/laravel-dashboard/v3/images/dashboard.png)
 
 The dashboard consists of tiles which are, under the hood, Livewire components. They can update themselves via polling. 
 
-You can use any of the [pre-packaged tiles](/docs/laravel-dashboard/v2/adding-tiles/overview) or [create your own](/docs/laravel-dashboard/v2/adding-tiles/creating-your-own-tile).
+You can use any of the [pre-packaged tiles](/docs/laravel-dashboard/v3/adding-tiles/overview) or [create your own](/docs/laravel-dashboard/v3/adding-tiles/creating-your-own-tile).
 
 ## Are you a visual learner?
 


### PR DESCRIPTION
Replaced all v2 links with their corresponding v3 versions and updated embedded images sourced from v2 to v3. This ensures the documentation consistently references the latest version.