### PR TITLE
Update OhDear Laravel Package documentation link

### DIFF
--- a/docs/adding-tiles/oh-dear-uptime.md
+++ b/docs/adding-tiles/oh-dear-uptime.md
@@ -15,7 +15,7 @@ You can install the package via composer:
 composer require spatie/laravel-dashboard-oh-dear-uptime-tile
 ```
 
-This package listens for events coming from Oh Dear using the `ohdearapp/laravel-ohdear-webhooks` package. Before you can use this tile, you must set up `laravel-ohdear-webhooks`. You'll find instructions [in this section in the Oh Dear docs](https://ohdear.app/docs/integrations/webhooks/laravel-package).
+This package listens for events coming from Oh Dear using the `ohdearapp/laravel-ohdear-webhooks` package. Before you can use this tile, you must set up `laravel-ohdear-webhooks`. You'll find instructions [in this section in the Oh Dear docs](https://ohdear.app/docs/integrations/webhooks#laravel-package).
 
 In the `dashboard` config file, you must add this configuration in the `tiles` key.
 


### PR DESCRIPTION
It's just a small fix on the link to [OhDear Webhooks Laravel Package](https://ohdear.app/docs/integrations/webhooks#laravel-package) documentation page/section. 